### PR TITLE
Refactor Dockerfile and update watchdog

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,12 @@
-FROM alpine:3.6 as watchdog
+FROM openfaas/classic-watchdog:0.13.4 as watchdog
 
-RUN apk add --no-cache curl \
-    && curl -sL https://github.com/alexellis/faas/releases/download/0.6.9/fwatchdog > \
-    /usr/bin/fwatchdog \
-    && chmod +x /usr/bin/fwatchdog
-
-FROM alpine:3.6
+FROM alpine:3.8
 ENTRYPOINT []
 
-COPY --from=watchdog /usr/bin/fwatchdog /usr/bin/fwatchdog
+COPY --from=watchdog /fwatchdog /usr/bin/fwatchdog
 
-RUN apk add --no-cache youtube-dl bash ca-certificates
+RUN apk add --no-cache py-pip bash ca-certificates
+RUN pip install --upgrade youtube-dl
 
 COPY entry.sh   .
 RUN chmod +x entry.sh

--- a/stack.yml
+++ b/stack.yml
@@ -1,11 +1,14 @@
 provider:
-  name: faas
-  provider: faas
-  gateway: http://localhost:8080
+  name: openfaas
+  gateway: http://127.0.0.1:8080
 
 functions:
   youtubedl:
     lang: Dockerfile
     handler: ./
-    image: alexellis2/faas-youtubedl:0.3
-
+    image: rgee0/faas-youtubedl:0.4
+    environment:
+      read_timeout: 300s
+      write_timeout: 300s
+    labels: 
+      com.openfaas.ui.ext: "mp4"


### PR DESCRIPTION
The function being deployed from the store is broken.  The error is `"token" parameter not in video info for unknown reason` and the cause is well documented.  A fix has been applied and it appears as though the apk package that was in use is trailing other distribution mechanisms.

This change swaps to the version distributed by pip.  It also updates the watchdog to use the Docker image version.  Also updates the stack fileto a add the ext label.

Signed-off-by: Richard Gee <richard@technologee.co.uk>